### PR TITLE
Fixed App crashing in non ASCII Window Name

### DIFF
--- a/Controllers/EKWindow.py
+++ b/Controllers/EKWindow.py
@@ -16,8 +16,9 @@ import sys
 
 
 class EKWindow(QDialog, dialog_ui.Ui_Dialog):
-    def __init__(self):
+    def __init__(self, app):
         QDialog.__init__(self)
+        self.app = app
         self.app_path = os.getenv("APPDATA") + "\\" + qApp.applicationName()
         self.registrySettings = QSettings("HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run", QSettings.NativeFormat)
         self.table_path = self.app_path + "\\tables"
@@ -143,8 +144,7 @@ class EKWindow(QDialog, dialog_ui.Ui_Dialog):
 
     def quit(self):
         self.engine.un_hook()
-        win32api.PostThreadMessage(win32api.GetCurrentThreadId(), win32con.WM_QUIT, 0, 0)
-        self.exit(0)
+        self.app.exit(0)
 
     def show_setting(self):
         self.stacked_widget.setCurrentIndex(0)

--- a/EkEngine/Engine.py
+++ b/EkEngine/Engine.py
@@ -31,10 +31,14 @@ class Engine(Thread):
         self.scim_mapping_reversed = {}
         self.valid_chars = []
         self.hm = pyHook.HookManager()
+        self.quit_thread = False
 
     def run(self):
         self.initialize()
         self.hook()
+        # Making sure to remove hm in case
+        self.un_hook()
+        return
 
     def initialize(self):
         table_parser = ScimTableParser()
@@ -44,6 +48,7 @@ class Engine(Thread):
 
     def un_hook(self):
         try:
+            self.quit_thread = True
             self.hm.__del__()
         except:
             pass
@@ -52,7 +57,8 @@ class Engine(Thread):
         self.hm.KeyDown = self.on_keyboard_event
         self.hm.KeyUp = self.on_keyup_event
         self.hm.HookKeyboard()
-        pythoncom.PumpMessages()
+        while not self.quit_thread:
+            pythoncom.PumpWaitingMessages()
 
     def setvalid_chars(self):
         keys_list = list(self.scim_mapping.keys())

--- a/EkEngine/Engine.py
+++ b/EkEngine/Engine.py
@@ -1,4 +1,4 @@
-import pyHook
+import pyWinhook as pyHook
 import pythoncom
 
 from threading import Thread

--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@ __maintainer__ = "http://thamizha.com/"
 __email__ = ""
 __status__ = "Development"
 
+# Entry file which will bootstrap the app and start the application
+
 import time
 import sys
 
@@ -22,22 +24,32 @@ from Controllers import EKWindow
 class Main:
 
     def __init__(self):
+        # Initialize
         app = QApplication(sys.argv)
         app.setApplicationName("eKalappai")
         app.setApplicationVersion("4.0.0")
         shared = QSharedMemory("59698760-43bb-44d9-8121-181ecbb70e4d")
 
+        # Check if already another instance of app is running and quit if it is
         if not shared.create(512, QSharedMemory.ReadWrite):
             qWarning("Cannot start more than one instance of eKalappai any time.")
             exit(0)
+
+        # Splash Screen init
         splashImage = QPixmap(':intro/splash_screen')
         splashScreen = QSplashScreen(splashImage)
         splashScreen.show()
+        # Time wait for splash screen to be shown
         time.sleep(2)
         splashScreen.hide()
+
+        # Main application starting
         QApplication.setQuitOnLastWindowClosed(False)
-        ekWindow = EKWindow()
+        ekWindow = EKWindow(app)
+
+        # EK Engine start
         ekWindow.engine.start()
+        
         sys.exit(app.exec_())
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+PyQt5
+peewee
+pywin32
+pyWinHook
+pyinstaller


### PR DESCRIPTION
This PR contains the following changes.

- Error closing the app fixed by implementing non-blocking pumping messages with pythoncom and then properly closing the core app

- PyHook replaced with PyWinHook for better Python 3 support which resolves the app crashing with non-ASCII window name application

- Requirements.txt added to help with CICD